### PR TITLE
fix: patch security vulnerabilities in dependencies (CTO-4384, CTO-45…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,10 @@ beautifulsoup4==4.9.3
 bs4==0.0.1
 cachetools==4.1.1
 certifi==2024.7.4
-cffi==1.15.1
+cffi==2.0.0
 chardet==3.0.4
 configparser==5.0.1
-cryptography==43.0.1
+cryptography==46.0.5
 decorator==4.4.2
 defusedxml==0.7.1
 Deprecated==1.2.10
@@ -54,16 +54,16 @@ pre-commit==2.21.0
 prompt-toolkit==3.0.8
 ptpython==3.0.7
 ptyprocess==0.6.0
-pyasn1==0.4.8
-pyasn1-modules==0.2.8
+pyasn1==0.6.3
+pyasn1-modules==0.4.2
 pycparser==2.20
 pyflakes==3.0.0
 PyGithub==1.56
 Pygments==2.15.0
-PyJWT==2.9.0
+PyJWT==2.12.0
 PyMySQL==1.1.1
 PyNaCl==1.5.0
-pyOpenSSL==24.2.1
+pyOpenSSL==26.0.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
 python-Levenshtein==0.12.0
@@ -84,7 +84,7 @@ soupsieve==2.0.1
 sqlparse==0.5.1
 traitlets==5.0.5
 uritemplate==3.0.1
-urllib3==2.2.2
+urllib3==2.6.3
 wcwidth==0.2.5
 zipp==3.19.1
 selenium==4.23.1
@@ -120,3 +120,4 @@ django-session-timeout==0.1.0
 django-axes==5.41.1
 jsonschema==4.17.3
 types-jsonschema==4.17.0
+


### PR DESCRIPTION
- cryptography 43.0.1 → 46.0.5 (CVE-2026-26007: subgroup attack on SECT curves)
- cffi 1.15.1 → 2.0.0 (required by cryptography>=46.0.0 on Python 3.9+)
- pyOpenSSL 24.2.1 → 26.0.0 (CVE-2026-27459: DTLS cookie callback buffer overflow)
- PyJWT 2.9.0 → 2.12.0 (CVE-2026-32597: unknown crit header extensions accepted, CVSS 7.5)
- pyasn1 0.4.8 → 0.6.3 (GHSA-jr27-m4p2-rc6r: DoS via unbounded recursion, CVSS 7.5)
- pyasn1-modules 0.2.8 → 0.4.2 (required by pyasn1>=0.6.1 compatibility)