### PR TITLE
security: mitigate urllib3 decompression-bomb bypass (CTO-4807)

### DIFF
--- a/EnigmaAutomation/__init__.py
+++ b/EnigmaAutomation/__init__.py
@@ -1,3 +1,4 @@
+from . import security_mitigations  # noqa: F401  applied at import time
 from .celery import app as celery_app
 
 __all__ = ("celery_app",)

--- a/EnigmaAutomation/security_mitigations.py
+++ b/EnigmaAutomation/security_mitigations.py
@@ -1,0 +1,35 @@
+"""
+Runtime security mitigations applied at process startup.
+
+Each mitigation here should reference the ticket / advisory it addresses
+and be removed once the underlying issue is properly resolved (typically
+by a dependency upgrade).
+"""
+
+import requests.adapters
+
+
+_original_send = requests.adapters.HTTPAdapter.send
+
+
+def _force_identity_encoding(self, request, *args, **kwargs):
+    """Mitigation for GHSA-mf9v-mfxr-j63j (CTO-4807).
+
+    urllib3 < 2.7.0 has a decompression-bomb safeguard bypass in parts of
+    its streaming API. urllib3 2.7.0 (the patched version) requires
+    Python >= 3.10, but this project's CI matrix still includes Python 3.9
+    so we cannot bump the pin.
+
+    Forcing Accept-Encoding: identity on every outbound HTTP request makes
+    servers return uncompressed bodies, so urllib3's decompression code
+    path is never exercised at runtime and the bug cannot trigger.
+
+    Remove this patch (and the import from EnigmaAutomation/__init__.py)
+    once the Python runtime is upgraded and urllib3 can be bumped to
+    >= 2.7.0.
+    """
+    request.headers["Accept-Encoding"] = "identity"
+    return _original_send(self, request, *args, **kwargs)
+
+
+requests.adapters.HTTPAdapter.send = _force_identity_encoding


### PR DESCRIPTION
## Summary

- [GHSA-mf9v-mfxr-j63j](https://github.com/advisories/GHSA-mf9v-mfxr-j63j) flags a decompression-bomb safeguard bypass in urllib3 streaming code, fixed in **urllib3 2.7.0**.
- urllib3 2.7.0 requires **Python ≥ 3.10**, but our CI matrix still includes 3.9 (dropping it isn't an option right now), so we can't bump the pin. See blocked dependabot PR #300.
- This PR installs a runtime mitigation: force `Accept-Encoding: identity` on every outbound HTTP request. With no compressed responses ever arriving, urllib3's decompression path is never exercised → the bug can't trigger.
- Added a new module `EnigmaAutomation/security_mitigations.py` and imported it once from `EnigmaAutomation/__init__.py` so the patch loads in every process (Django web, manage.py CLI, celery workers, pytest with `DJANGO_SETTINGS_MODULE` set).

## How it works
\`\`\`python
# requests.adapters.HTTPAdapter.send is wrapped to inject the header
request.headers["Accept-Encoding"] = "identity"
\`\`\`
Every \`requests.get/post/...\` (and anything else built on \`requests\`, which is what urllib3 is pulled in via in this codebase) now negotiates an uncompressed response. Servers respect \`identity\` per RFC 9110.

## Scope of impact
- ⚠️ Outbound HTTP responses arrive uncompressed → slightly more bandwidth for endpoints that used to send gzip. Acceptable for an access-management service.
- Caveat: SCA scanners detect by **version**, not runtime behavior. CTO-4807 will continue to flag \`urllib3==2.6.3\` until we either upgrade Python and bump urllib3, or security accepts the risk with this mitigation as justification.

## Test plan
- [ ] CI green on all 3 Python versions (3.9, 3.10, 3.11)
- [ ] Smoke-test in staging: confirm outbound calls to OAuth/IDP/etc. still function with \`Accept-Encoding: identity\`
- [ ] Verify in logs / debugger that the request header is set on at least one outbound call
- [ ] File security-team risk acceptance for CTO-4807 with this PR linked as the mitigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)