### PR TITLE
build(deps): bump PyYAML from 6.0 to 6.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ python3-openid==3.2.0
 pytz==2021.3
 pyvim==3.0.2
 pyvmomi==7.0.1
-PyYAML==6.0
+PyYAML==6.0.2
 requests==2.32.3
 requests-oauthlib==1.3.0
 rsa==4.7


### PR DESCRIPTION
## Summary
- Bump `PyYAML==6.0` → `PyYAML==6.0.2` in `requirements.txt`
- Fixes the perpetually-red **Automatic Dependency Submission (Python)** check on every PR (e.g. #302) and on `main`

## Why

PyYAML 6.0's sdist `setup.py` references `cython_sources` on a `build_ext` instance, an attribute that no longer exists in Cython 3 / setuptools 70+. GitHub's runner now uses Python 3.12, and no PyYAML 6.0 wheel exists for 3.12 — so `pip-compile` falls back to building from sdist and dies:

```
File "<string>", line 204, in get_source_files
AttributeError: 'build_ext' object has no attribute 'cython_sources'
```

This has been failing on `main` since at least 2026-05-12 (the last 4+ runs of `submit-pypi` are red), making the check noisy on every PR — including the security PR #302.

PyYAML **6.0.2** (Aug 2024):
- Ships prebuilt Python 3.12 wheels (so sdist build is skipped entirely on the runner)
- Patches the `setup.py` for Cython 3 sdist builds
- Patch-level bump within the 6.0 line — no API change

## Test plan
- [x] `submit-pypi` / `Automatic Dependency Submission (Python)` turns green on this PR
- [x] CI build matrix (3.9 / 3.10 / 3.11) still passes — PyYAML import surface is unchanged
- [ ] Once merged, re-run on PR #302 should clear that PR's red check too

🤖 Generated with [Claude Code](https://claude.com/claude-code)