### PR TITLE
Potential fix for code scanning alert no. 84: DOM text reinterpreted as HTML

### DIFF
--- a/templates/EnigmaOps/allUserAccessList.html
+++ b/templates/EnigmaOps/allUserAccessList.html
@@ -109,13 +109,15 @@ var current_username = "";
 
   function revokeConfirm(access_type_or_id, username=null){
     current_username = username
-    html = "<h4> Revoke Request ID: "+access_type_or_id+"?</h4>"
+    var message = "Revoke Request ID: " + access_type_or_id + "?"
     if(access_type_or_id.startsWith("module-")){
-      html = "<h4> Revoke all accesses for user "+username+" for "+access_type_or_id+"?</h4>"
+      message = "Revoke all accesses for user " + username + " for " + access_type_or_id + "?"
     }
     revokeButton = document.getElementsByName("final-revoke-button")[0]
     revokeButton.id = access_type_or_id
-    $("#revoke-details").html(html)
+    var $details = $("#revoke-details");
+    $details.empty();
+    $details.append($("<h4>").text(message));
   }
 
   function openType(elem) {


### PR DESCRIPTION
Potential fix for [https://github.com/browserstack/enigma/security/code-scanning/84](https://github.com/browserstack/enigma/security/code-scanning/84)

General fix: stop building HTML strings from untrusted values and stop using `.html()` for those strings. Instead, create DOM nodes and set text via `.text()` (or `textContent`), which safely escapes meta-characters.

Best targeted fix here (same functionality): in `templates/EnigmaOps/allUserAccessList.html`, update `revokeConfirm` so it:
- Computes the message string only.
- Clears `#revoke-details`.
- Appends an `<h4>` element with `.text(message)`.

This preserves the same displayed text and modal behavior while removing the unsafe HTML sink usage for tainted data. No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
