### PR TITLE
security(auth): require login on 4 unauthenticated state-changing views (F-002/003/004/005)

### DIFF
--- a/Access/views.py
+++ b/Access/views.py
@@ -294,6 +294,7 @@ def group_dashboard(request):
     return render(request, "EnigmaOps/createNewGroup.html")
 
 
+@login_required
 def approve_new_group(request, group_id):
     """Approve a new group request.
 
@@ -448,6 +449,7 @@ def decline_access(request, access_type, request_id):
     return JsonResponse({"error": "Invalid request"}, status=400)
 
 
+@login_required
 def remove_group_member(request):
     """Remove a user from a group.
 
@@ -628,6 +630,7 @@ def mark_revoked(request):
     return JsonResponse(json_response, status=403)
 
 
+@login_required
 def individual_resolve(request):
     json_response = {"status_list": []}
     try:
@@ -738,6 +741,7 @@ def resolve_bulk(request):
         json_response['error'] = {'error_msg': "Bad request", 'msg': "Error in request not found OR Invalid request type"}
         return render(request,'EnigmaOps/accessStatus.html',json_response)
 
+@login_required
 def revoke_group_access(request):
     try:
         response = group_helper.revoke_access_from_group(request)


### PR DESCRIPTION
## Summary

Closes 4 **unauthenticated state-changing** findings by adding `@login_required` to routed views that mutate state without any auth check.

| Finding | Ticket | View | Route |
|---|---|---|---|
| F-002 | CTO-4854 | `approve_new_group` | `/group/new/accept/<id>` |
| F-003 | CTO-4855 | `remove_group_member` | `/group/removeGroupMember` |
| F-004 | CTO-4856 | `individual_resolve` | `/individual_resolve` |
| F-005 | CTO-4857 | `revoke_group_access` | `/group/revokeAccess` |

All four were the **only** routed, state-changing views in `Access/views.py` lacking an auth decorator (verified by enumerating every `def` + its decorator). Fix matches the existing pattern used by sibling views (`accept_bulk`, `decline_access`, `update_group_owners`, …).

Deliberately **not** decorated: Django's `error_404`/`error_500` handlers and the private `_get_request_ids_for_bulk_processing` helper (not routed).

## Scope
Auth *decorator* gap only. The two **IDOR** findings in this area — F-006 (CTO-4858, `mark_revoked` ownership) and F-022 (CTO-4869, `accept_bulk` ownership scope) — need ownership-check logic and are a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
