### PR TITLE
security(authz): mark_revoked requires ALLOW_USER_OFFBOARD not read perm (F-006, CTO-4858)

### DIFF
--- a/Access/views.py
+++ b/Access/views.py
@@ -575,7 +575,7 @@ def all_user_access_list(request, load_ui=True):
 
 
 @login_required
-@user_with_permission(["VIEW_USER_ACCESS_LIST"])
+@user_with_permission(["ALLOW_USER_OFFBOARD"])
 def mark_revoked(request):
     """Revoke an access
 


### PR DESCRIPTION
## Summary

Fixes **F-006 (CTO-4858, Critical, CVSS 8.1 IDOR)** — `mark_revoked` performs a destructive, cross-user access **revocation** but was gated only by `@user_with_permission(["VIEW_USER_ACCESS_LIST"])`, a **read** permission. Any operator with read visibility could revoke *any* user's access (`GET /access/markRevoked?requestId=module-aws&username=<victim>`).

**Fix:** require `ALLOW_USER_OFFBOARD` instead — the permission already used to authorize revocation/offboarding elsewhere in the codebase:
- `group_helper.revoke_access_from_group` (`group_helper.py:832`)
- `Access/models.py:222` (`User.offboard` authorization)
- `Access/userlist_helper.py` (offboard flow)

The read view `all_user_access_list` correctly **keeps** `VIEW_USER_ACCESS_LIST`.

## Note on F-022 (CTO-4869) — NOT changed here, needs a decision

F-022 claims `accept_bulk` lets any logged-in user self-approve any request. Reading the code, that premise doesn't hold: the approval helpers already enforce proper authorization —
- `accept_user_access_requests` and `accept_group_access` fetch **module-specific** approver permissions (`_get_approver_permissions`), enforce `check_user_permissions` + primary/secondary approver checks, and **block self-approval** (`SELF_APPROVAL_ERROR` / `is_self_approval`).

The finding's suggested fix ("gate all paths on `ACCESS_APPROVE`") would actually **break legitimate module-specific approvers** (who approve via module perms, not the global `ACCESS_APPROVE`). So I've deliberately left `accept_bulk` unchanged and flagged F-022 for re-verification rather than shipping a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
