### PR TITLE
security(xss): DOM-safe rendering in access list + pending requests (F-024/F-025)

### DIFF
--- a/templates/EnigmaOps/allUserAccessList.html
+++ b/templates/EnigmaOps/allUserAccessList.html
@@ -156,40 +156,69 @@ var current_username = "";
     urlBuilder = buildUrlFromParams("json");
     $.ajax({url: urlBuilder,
         success: function(result){
-          html_string = "No Results"
-          for(i=0;i<result["dataList"].length;i++){
-            record = result["dataList"][i]
-            html_string += "<tr>"
-            html_string += "<td>"+record["user"]+"</td>"
-            html_string += "<td>"+record["access_desc"]+"</td>"
-            html_string += "<td>"
-            for(j=0;j<record["access_label"].length;j++)
-              html_string += record["access_label"][j]+"<br>"
-            html_string += "</td>"
-            if(record["status"] != "Revoked"){
-              html_string += "<td id='"+record["requestId"]+"-access-status'>"+record["status"]+"</td>"
-            }
-            else{
-              html_string += "<td id='"+record["requestId"]+"-access-status'>"+record["status"]+"<br>By-"+record["revoker"]+"</td>"
-            }
-            html_string += "<td id='"+record["requestId"]+"-revoke-button'>"
-            if(record["status"] != "Revoked")
-              html_string += '<button id="'+record["requestId"]+`" class="btn btn-danger" data-toggle="modal" data-target="#revokeModal" onclick='revokeConfirm("`+record["requestId"]+`")'>Mark Revoked</button>`
-            html_string += "</td>"
-            html_string += "<td>"+record["requested_on"]+"</td>"
-            html_string += "<td>"+record["approver"]+"</td>"
-            html_string += "<td>"+record["updated_on"]+"</td>"
-            html_string += "<td>"+record["offboarding_date"]+"</td>"
-            html_string += "<td>"+record["grantOwner"]+"</td>"
-            html_string += "<td>"+record["revokeOwner"]+"</td>"
-            html_string += "<td>{% if is_ops %} <a class=\"btn btn-primary\" target=\"_blank\" href=\"/individual_resolve?requestId="+encodeURIComponent(record["requestId"])+"&ops_resolve=true\">ReGrant</a></td>{% endif %}"
-            html_string += "<td>"+record["type"]+"</td>"
-            html_string += "</tr>"
+          // F-024: build rows with DOM APIs + .text() so DB-stored, user-controlled
+          // fields (requestId/user/approver/...) are treated as text, never HTML.
+          var isOps = {% if is_ops %}true{% else %}false{% endif %};
+          var $tbody = $("#tableData");
+          $tbody.empty();
+          var dataList = result["dataList"] || [];
+          if (dataList.length === 0) {
+            $tbody.text("No Results");
           }
-          $("#tableData").html(html_string);
+          for(var i=0;i<dataList.length;i++){
+            var record = dataList[i]
+            var $tr = $("<tr>");
+            $tr.append($("<td>").text(record["user"]));
+            $tr.append($("<td>").text(record["access_desc"]));
+            var $labelTd = $("<td>");
+            for(var j=0;j<record["access_label"].length;j++){
+              $labelTd.append(document.createTextNode(record["access_label"][j]));
+              $labelTd.append($("<br>"));
+            }
+            $tr.append($labelTd);
+            var $statusTd = $("<td>").attr("id", record["requestId"]+"-access-status");
+            if(record["status"] != "Revoked"){
+              $statusTd.text(record["status"]);
+            } else {
+              $statusTd.append(document.createTextNode(record["status"]));
+              $statusTd.append($("<br>"));
+              $statusTd.append(document.createTextNode("By-"+record["revoker"]));
+            }
+            $tr.append($statusTd);
+            var $btnTd = $("<td>").attr("id", record["requestId"]+"-revoke-button");
+            if(record["status"] != "Revoked"){
+              var $btn = $("<button>", {
+                "class": "btn btn-danger",
+                "data-toggle": "modal",
+                "data-target": "#revokeModal",
+                "id": record["requestId"]
+              }).text("Mark Revoked");
+              // read the request id off the element — no inline onclick/JS-context injection
+              $btn.on("click", function(){ revokeConfirm($(this).attr("id")); });
+              $btnTd.append($btn);
+            }
+            $tr.append($btnTd);
+            $tr.append($("<td>").text(record["requested_on"]));
+            $tr.append($("<td>").text(record["approver"]));
+            $tr.append($("<td>").text(record["updated_on"]));
+            $tr.append($("<td>").text(record["offboarding_date"]));
+            $tr.append($("<td>").text(record["grantOwner"]));
+            $tr.append($("<td>").text(record["revokeOwner"]));
+            var $regrantTd = $("<td>");
+            if(isOps){
+              $regrantTd.append($("<a>", {
+                "class": "btn btn-primary",
+                "target": "_blank",
+                "href": "/individual_resolve?requestId="+encodeURIComponent(record["requestId"])+"&ops_resolve=true"
+              }).text("ReGrant"));
+            }
+            $tr.append($regrantTd);
+            $tr.append($("<td>").text(record["type"]));
+            $tbody.append($tr);
+          }
           page_number = result['current_page'];
 
-          $("#pagedisplay").html("Page "+String(result['current_page'])+" of "+String(result['last_page']))
+          $("#pagedisplay").text("Page "+String(result['current_page'])+" of "+String(result['last_page']))
         },
         error: function(result){
           alert("Error occured while fetching data")

--- a/templates/EnigmaOps/pendingRequests.html
+++ b/templates/EnigmaOps/pendingRequests.html
@@ -173,6 +173,15 @@
 
         $(".dropdown-menu a:first-child").trigger('click')
 
+        // F-025: server-supplied msg/error must be inserted as text, not HTML.
+        function setColoredMessage(el, text, color) {
+            if (!el) return;
+            el.innerHTML = "";
+            var p = document.createElement("p");
+            p.style.color = color;
+            p.textContent = text;
+            el.appendChild(p);
+        }
         function updateStatus(result, selector) {
             for (var request_id in result["response"]) {
                 div_id = request_id + "-action"
@@ -181,13 +190,11 @@
                     document.getElementById(chkbox).innerHTML = ""
                 if (result["response"][request_id]["success"]) {
                     msg = result["response"][request_id]["msg"]
-                    if (document.getElementById(div_id))
-                        document.getElementById(div_id).innerHTML = "<p style='color: #68e068'>" + msg + "</p>"
+                    setColoredMessage(document.getElementById(div_id), msg, "#68e068")
                 }
                 else {
                     error = result["response"][request_id]["error"];
-                    if (document.getElementById(div_id))
-                        document.getElementById(div_id).innerHTML = "<p style='color: red'>" + error + "</p>"
+                    setColoredMessage(document.getElementById(div_id), error, "red")
                 }
             }
             if (selector.endsWith("-club") || selector == "clubGroupAccess") {
@@ -278,7 +285,7 @@
                 },
                 error: function (result) {
                     error = result["responseJSON"]["error"]
-                    document.getElementById(div_id).innerHTML = "<p style='color: red'>" + error + "</p>"
+                    setColoredMessage(document.getElementById(div_id), error, "red")
                     modal.style.display = "none";
                     document.getElementById("decline-processing").innerHTML = ""
                 }
@@ -297,7 +304,7 @@
             request_id = $(this).val()
             modal.style.display = "block";
             $('#declineUrlParams').val(selector)
-            document.getElementById("declineHeading").innerHTML = "Decline " + request_id
+            document.getElementById("declineHeading").textContent = "Decline " + request_id
         });
 
         $('#declineReason').on('change', function () {


### PR DESCRIPTION
Fixes two stored/DOM-XSS findings by rendering server-supplied, user-influenced strings as **text, not HTML**.

**F-024 (CTO-4871)** — `allUserAccessList.html` `updateTable()`: rebuilt rows with jQuery DOM APIs + `.text()` instead of concatenating DB fields into an `html_string` fed to `.html()`. The revoke button now reads its request id off the element via an event listener — this removes the inline `onclick='revokeConfirm("…")'` sink, which HTML-encoding alone could **not** fix (entities decode back to raw chars in the JS attribute context).

**F-025 (CTO-4872)** — `pendingRequests.html`: server `msg`/`error` and `request_id` were concatenated into `innerHTML`. Added `setColoredMessage()` (styled `<p>` built via `textContent`) and switched the decline heading to `textContent`.

**Already fixed on main** (verified, can be closed): F-026 (`revokeConfirm` uses `.text()`) and CTO-4906 (`openType` DOM rebuild, comment *'Fixes CodeQL js/xss-through-dom'*).

⚠️ **Not render-tested** in this environment — the DOM rebuild preserves all 13 columns, the `-access-status`/`-revoke-button` element ids (used by the revoke AJAX handler), and the ops-only ReGrant link, but please smoke-test the access-list page renders + revoke works before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)